### PR TITLE
Bug fixes for request parsing

### DIFF
--- a/src/ColumnNameSanitizer.php
+++ b/src/ColumnNameSanitizer.php
@@ -25,6 +25,10 @@ class ColumnNameSanitizer
             throw InvalidColumnName::invalidCharacters($column);
         }
 
+        // JSONAPI expects properties with a hyphen but that doesn't mesh with
+        // our database column naming.
+        $column = str_replace('-', '_', $column);
+
         return $column;
     }
 

--- a/src/Scopes/RequestScope.php
+++ b/src/Scopes/RequestScope.php
@@ -35,15 +35,15 @@ class RequestScope implements Scope
      */
     protected function parsePagination() : void
     {
-        $page = (array) request()->get('page');
+        $page = (array) request()->input('page');
         // check for page[size], page[limit], or just limit
-        $limit = $page['size'] ?? $page['limit'] ?? request()->get('limit') ?? config('laravel-request-scope.defaultCollectionLimit', 50);
+        $limit = $page['size'] ?? $page['limit'] ?? request()->input('limit') ?? config('laravel-request-scope.defaultCollectionLimit', 50);
         // keep ridiculous limits away
         if ($limit > config('laravel-request-scope.maxCollectionLimit', 1000)) {
             $limit = config('laravel-request-scope.maxCollectionLimit', 1000);
         }
         // check for page[offset] or just offset
-        $offset = $page['offset'] ?? request()->get('offset') ?? 0;
+        $offset = $page['offset'] ?? request()->input('offset') ?? 0;
         // check for page[number] and replace offset with number * limit
         if (isset($page['number'])) {
             $offset = $page['number'] * $limit;
@@ -55,7 +55,7 @@ class RequestScope implements Scope
 
     protected function parseFilters(): void
     {
-        if (!$filters = request()->get(config('laravel-request-scope.filterParameter', 'filter'))) {
+        if (!$filters = request()->input(config('laravel-request-scope.filterParameter', 'filter'))) {
             return;
         }
         if (!is_array($filters)) {
@@ -91,7 +91,7 @@ class RequestScope implements Scope
 
     protected function parseIncludes()
     {
-        $includes = request()->get(config('laravel-request-scope.includeParameter', 'include'));
+        $includes = request()->input(config('laravel-request-scope.includeParameter', 'include'));
         foreach (explode(',', $includes) as $include) {
             if (!$include) {
                 continue;
@@ -102,7 +102,7 @@ class RequestScope implements Scope
 
     protected function parseSorts()
     {
-        if (!$sorts = request()->get(config('laravel-request-scope.sortParameter', 'sort'))) {
+        if (!$sorts = request()->input(config('laravel-request-scope.sortParameter', 'sort'))) {
             return;
         }
         $sorts = explode(',', $sorts);
@@ -118,7 +118,7 @@ class RequestScope implements Scope
 
     protected function parseFields()
     {
-        if (!$fields = request()->get(config('laravel-request-scope.fieldsParameter', 'fields'))) {
+        if (!$fields = request()->input(config('laravel-request-scope.fieldsParameter', 'fields'))) {
             return;
         }
         $select = [];

--- a/src/Services/FilterParser.php
+++ b/src/Services/FilterParser.php
@@ -72,7 +72,7 @@ class FilterParser {
     public static function parse($rawFilters): Collection {
         $ret = [];
         foreach ($rawFilters as $field => $grouped_filter) {
-            $split_filters = explode(config('laravel-request-scope.filterSeparator', ','), $grouped_filter);
+            $split_filters = explode(config('laravel-request-scope.filterSeparator', ','), (string)$grouped_filter);
             foreach ($split_filters as $individual_filter) {
                 $ret[$field][] = self::parseOperator($individual_filter);
             }


### PR DESCRIPTION
Fixes:

* JSONAPI expects hyphens but databases want underscores
* Changes to $request don't reflect inside of RequestScope
* On projects with strict type enabled the parsing can error out when given an int instead of string