### PR TITLE
Move Query Builder method names out of parser

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,8 +9,8 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [7.4]
-        laravel: [7.*]
+        php: [7.4, 8.1]
+        laravel: [8.*]
         stability: [prefer-stable]
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}

--- a/src/Scopes/RequestScope.php
+++ b/src/Scopes/RequestScope.php
@@ -55,11 +55,11 @@ class RequestScope implements Scope
     protected function parseFilters(): void
     {
         $filters = request()->input(config('laravel-request-scope.filterParameter', 'filter'));
-        if (empty($filters) || !is_array($filters)) {
+        if (empty($filters) || ! is_array($filters)) {
             return;
         }
 
-        if (!empty($filters['tags'])) {
+        if (! empty($filters['tags'])) {
             $this->processTagFilters($filters);
         }
 

--- a/src/Services/FilterParser.php
+++ b/src/Services/FilterParser.php
@@ -133,7 +133,7 @@ class FilterParser
                 ];
             case config('laravel-request-scope.betweenOperator', 'bt'):
                 return [
-                    'operator' => 'whereBetween',
+                    'operator' => 'between',
                     'value' => explode(config('laravel-request-scope.betweenSeparator', ';'), $value, 2),
                 ];
             case config('laravel-request-scope.likeOperator', 'like'):
@@ -158,12 +158,12 @@ class FilterParser
                 ];
             case config('laravel-request-scope.inOperator', 'in'):
                 return [
-                    'operator' => "whereIn",
+                    'operator' => 'in',
                     'value' => explode(config('laravel-request-scope.inSeparator', ';'), $value),
                 ];
             case config('laravel-request-scope.notInOperator', 'notin'):
                 return [
-                    'operator' => 'whereNotIn',
+                    'operator' => 'notIn',
                     'value' => explode(config('laravel-request-scope.inSeparator', ';'), $value),
                 ];
         }

--- a/src/Services/FilterParser.php
+++ b/src/Services/FilterParser.php
@@ -11,7 +11,9 @@ use RuntimeException;
 /**
  * Class FilterParser.
  *
- * Parses a set of string filters into a usable array.
+ * Parses a set of string filters into a usable array. This is meant to be a
+ * generic parser that can be used outside Eloquent or a Query Builder context.
+ * This means the values here should not necessarily be tied to query methods.
  */
 class FilterParser
 {
@@ -105,6 +107,16 @@ class FilterParser
 
         [$operator, $value] = explode(config('laravel-request-scope.operatorSeparator', '|'), $filter, 2);
 
+        /**
+         * IMPORTANT! Operators here are not meant to be the same as Eloquent or
+         * Query Builder methods. These are generic names (or symbols) that are
+         * used outside of the RequestScope scope itself. Changing 'operator'
+         * values here will break other applications and libraries that rely on
+         * this parser class.
+         *
+         * Mapping to Query Builder or Eloquent methods/scopes happens inside of
+         * the RequestScope class itself.
+         */
         switch ($operator) {
             case config('laravel-request-scope.lessThanOperator', 'lt'):
                 return [

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -57,6 +57,9 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
             'includeParameter' => 'include',
             'sortParameter' => 'sort',
             'fieldsParameter' => 'fields',
+            'inOperator' => 'in',
+            'notInOperator' => 'notin',
+            'inSeparator' => ';',
         ]);
     }
 }

--- a/tests/TestingModel.php
+++ b/tests/TestingModel.php
@@ -21,6 +21,16 @@ class TestingModel extends Model
     protected $fillable = [
         'testing_field_one',
         'testing_field_two',
+        'testing_field_int',
+    ];
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $casts = [
+        'testing_field_one' => 'string',
+        'testing_field_two' => 'string',
+        'testing_field_int' => 'int',
     ];
 
     /**

--- a/tests/Unit/Scopes/RequestScopeTest.php
+++ b/tests/Unit/Scopes/RequestScopeTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Submtd\LaravelRequestScope\Tests\Unit\Scopes;
 
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Request;
 use Submtd\LaravelRequestScope\Scopes\RequestScope;
 use Submtd\LaravelRequestScope\Tests\TestCase;
@@ -16,60 +17,119 @@ use Submtd\LaravelRequestScope\Tests\TestingModel;
  */
 class RequestScopeTest extends TestCase
 {
+    protected ?Collection $foundModels = null;
+
+    protected ?Collection $notFoundModels = null;
+
+    public function dataProviderEloquentMappingData(): array
+    {
+        return [
+            'can filter between values' => [
+                [
+                    'testing_field_int' => 'bt|2;6',
+                ],
+            ],
+            'can filter in values' => [
+                [
+                    'testing_field_int' => 'in|3;5',
+                ],
+            ],
+            'can filter not in values' => [
+                [
+                    'testing_field_int' => 'notin|-1;1;17',
+                ],
+            ],
+        ];
+    }
+
+    public function dataProviderRequestTests(): array
+    {
+        return [
+            'can filter by multiple and complex' => [
+                [
+                    'testing_field_one' => 'foo',
+                    'testing_field_two' => 'foo,bar',
+                ],
+            ],
+        ];
+    }
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $findModelProps = [
+            [
+                'testing_field_one' => 'foo',
+                'testing_field_two' => 'bar',
+                'testing_field_int' => 3,
+            ],
+            [
+                'testing_field_one' => 'foo',
+                'testing_field_two' => 'foo',
+                'testing_field_int' => 5,
+            ],
+        ];
+
+        $notFindModelProps = [
+            [
+                'testing_field_one' => 'foo',
+                'testing_field_int' => 1,
+            ],
+            [
+                'testing_field_two' => 'foo',
+                'testing_field_int' => 17,
+            ],
+            [
+                'testing_field_two' => 'bar',
+                'testing_field_int' => 17,
+            ],
+            [
+                'testing_field_one' => 'bar',
+                'testing_field_int' => 17,
+            ],
+            [
+                'testing_field_two' => 'fizz',
+                'testing_field_int' => 17,
+            ],
+            [
+                'testing_field_one' => 'foo',
+                'testing_field_two' => 'fizz',
+                'testing_field_int' => 17,
+            ],
+            [
+                'testing_field_one' => 'bar',
+                'testing_field_two' => 'foo',
+                'testing_field_int' => -1,
+            ],
+        ];
+
+        $this->foundModels = TestingModel::factory()->createMany($findModelProps)->flatten();
+        $this->notFoundModels = TestingModel::factory()->createMany($notFindModelProps)->flatten();
+    }
+
     /**
+     * @param array $filters
+     *
+     * @return void
+     *
+     * @dataProvider dataProviderRequestTests
+     * @dataProvider dataProviderEloquentMappingData
      * @covers ::parseFilters
      */
-    public function test_parseFilters_builds_complex_query(): void
+    public function test_filters_map_to_eloquent_correctly(array $filters): void
     {
-        Request::replace([
-            'filter' => [
-                'testing_field_one' => 'foo',
-                'testing_field_two' => 'foo,bar',
-            ],
-        ]);
+        Request::replace(['filter' => $filters]);
 
-        $find_models =
-            TestingModel::factory(1)->createMany([
-                [
-                    'testing_field_one' => 'foo',
-                    'testing_field_two' => 'bar',
-                ],
-                [
-                    'testing_field_one' => 'foo',
-                    'testing_field_two' => 'foo',
-                ],
-            ])->flatten();
+        $query = (new TestingModel())->newModelQuery();
 
-        $not_find_models =
-            TestingModel::factory(1)->createMany([
-                ['testing_field_one' => 'foo'],
-                ['testing_field_two' => 'foo'],
-                ['testing_field_two' => 'bar'],
-                ['testing_field_one' => 'bar'],
-                ['testing_field_two' => 'fizz'],
-                [
-                    'testing_field_one' => 'foo',
-                    'testing_field_two' => 'fizz',
-                ],
-                [
-                    'testing_field_one' => 'bar',
-                    'testing_field_two' => 'foo',
-                ],
-            ])->flatten();
-
-
-        /** @var TestingModel $model */
-        $model = TestingModel::create();
-        $query = $model->newModelQuery();
-
-        $scope = new RequestScope();
-        $scope->apply($query, $model);
+        (new RequestScope())->apply($query, $query->getModel());
 
         $results = $query->get();
 
-        self::assertCount(2, $results);
+        self::assertCount($this->foundModels->count(), $results);
         self::assertEquals(
-            $find_models->pluck('id')->sort()->toArray(),
+            $this->foundModels->pluck('id')->sort()->toArray(),
             $results->pluck('id')->sort()->toArray()
         );
     }

--- a/tests/Unit/Services/FilterParserTest.php
+++ b/tests/Unit/Services/FilterParserTest.php
@@ -57,7 +57,7 @@ class FilterParserTest extends TestCase
             'ew is supported and works' => ['ew|example', 'like', '%example'],
             'eq is supported and works' => ['eq|example', '=', 'example'],
             'in is supported and works' => ['in|1;2', 'in', [1, 2]],
-            'notin in is supported and works' => ['notin|1;2', 'not', [1, 2]],
+            'notin in is supported and works' => ['notin|1;2', 'notIn', [1, 2]],
         ];
     }
 

--- a/tests/Unit/Services/FilterParserTest.php
+++ b/tests/Unit/Services/FilterParserTest.php
@@ -56,6 +56,8 @@ class FilterParserTest extends TestCase
             'sw is supported and works' => ['sw|example', 'like', 'example%'],
             'ew is supported and works' => ['ew|example', 'like', '%example'],
             'eq is supported and works' => ['eq|example', '=', 'example'],
+            'in is supported and works' => ['in|1;2', 'in', [1, 2]],
+            'notin in is supported and works' => ['notin|1;2', 'not', [1, 2]],
         ];
     }
 

--- a/tests/database/factories/TestingModelFactory.php
+++ b/tests/database/factories/TestingModelFactory.php
@@ -25,6 +25,7 @@ class TestingModelFactory extends Factory
         return [
             'testing_field_one' => $this->faker->realText(15),
             'testing_field_two' => $this->faker->realText(15),
+            'testing_field_int' => 0,
         ];
     }
 }

--- a/tests/database/migrations/0000_00_00_000000_create_testing_model_table.php
+++ b/tests/database/migrations/0000_00_00_000000_create_testing_model_table.php
@@ -27,11 +27,12 @@ class CreateTestingModelTable extends Migration
     {
         Schema::create(
             'testing_models',
-            function (Blueprint $table) {
+            static function (Blueprint $table) {
                 $table->id();
                 $table->timestamps();
-                $table->string('testing_field_one')->default('');
-                $table->string('testing_field_two')->default('');
+                $table->string('testing_field_one')->default('')->index();
+                $table->string('testing_field_two')->default('')->index();
+                $table->integer('testing_field_int')->default(0)->index();
             }
         );
     }


### PR DESCRIPTION
This PR:

* Adds support for named scopes to operator parsing (will prefer a scope named `between` before using `whereBetween`)
* Adds missing test coverage for the recently added IN and NOT IN.
* Fixes a breaking change where the `between` operator was changed to `whereBetween` causing breakage in applications.
* Removes all `where*` style operators in favor of the RequestScope figuring out methods, keeping the parser class separated from query building.

Existing functionality should remain unchanged outside of whereNotIn, whereIn, and whereBetween operators being renamed. This only impacts apps/packages using FilterParser directly.
